### PR TITLE
Update spanish translation

### DIFF
--- a/lang/Español.json
+++ b/lang/Español.json
@@ -2,13 +2,13 @@
     "english_name": "Spanish",
     "status": {
         "terminated": "\nLa aplicación se ha detenido.\nPor favor, cierre la aplicación.",
-        "watching": "Mirando el canal: {channel}",
+        "watching": "Viendo el canal: {channel}",
         "goes_online": "El canal {channel} se ha conectado, cambiando...",
         "goes_offline": "El canal {channel} se ha desconectado, cambiando...",
         "claimed_drop": "Drop reclamado: {drop}",
         "claimed_points": "Recompensa de puntos reclamados: {points}",
-        "earned_points": "Puntos obtenidos por mirar el stream: {points} | Total: {balance}",
-        "no_channel": "No se ha encontrado un canal en vivo para mirar. \nEsperando un canal en vivo...",
+        "earned_points": "Puntos obtenidos por ver el stream: {points} | Total: {balance}",
+        "no_channel": "No se ha encontrado un canal en directo para ver. \nEsperando un canal en directo...",
         "no_campaign": "No se ha encontrado una campaña activa. \nEsperando una nueva campaña..."
     },
     "login": {
@@ -39,7 +39,7 @@
             "exiting": "Saliendo...",
             "terminated": "Aplicación suspendida.",
             "cleanup": "Limpiando canales...",
-            "gathering": "Buscando canales en vivo...",
+            "gathering": "Buscando canales en directo...",
             "switching": "Cambiando de canal...",
             "fetching_inventory": "Obteniendo inventario...",
             "fetching_campaigns": "Obteniendo campañas...",
@@ -154,7 +154,7 @@
                 "campaigns": "Ver todas las campañas y administrar cuentas vinculadas"
             },
             "how_it_works": "Cómo funciona",
-            "how_it_works_text": "Cada aproximadamente 60 segundos, la aplicación envía un \"minuto visto\" al canal que se está mirando actualmente. \nDe esta forma, no es necesario descargar el video o sonido del stream. Ahorrando ancho de banda al usuario. \nCon el fin de mantener actualizados los estados (ONLINE o OFFLINE) de los canales, se establece una conexión websocket, \nque recibe información de los streams para poder actualizar el estado, o cantidad de espectadores actuales.",
+            "how_it_works_text": "Aproximadamente cada 20 segundos, la aplicación solicita a Twitch la URL de los datos del canal que estamos viendo. \nDe esta forma, obtenemos sus metadatos, lo que nos permite ahorrar en la descarga de video o audio del stream. \nPara mantener actualizados los estados (ONLINE o OFFLINE) de los canales, así como el número de espectadores, \nse establece una conexión WebSocket mediante de la cual recibimos la información actualizada de los streams.",
             "getting_started": "Primeros pasos",
             "getting_started_text": "1. Inicie sesión en la aplicación. \n2. Verifique que su cuenta de Twitch esté vinculada a todas las campañas deseadas a minar. \n3. Si desea minar todas las campañas, desmarque la opción \"Minar solo juegos preferidos\" y presione \"Recargar\". \n4. Si desea darle prioridad a una campaña específica, utilice la \"Lista de juegos preferidos\" para crear una lista de prioridad. \nLos juegos en la parte superior de la lista se intentarán minar antes de los que estén más abajo. \n5. Utilice la opción \"Minar solo juegos preferidos\" si desea evitar minar juegos que no estén en la lista de juegos preferidos. \n6. Utilice la \"Lista de juegos excluidos\" si desea evitar minar juegos que no estén en la lista de juegos excluidos. \n7. Al utilizar la opción \"Minar solo juegos preferidos\" o al cambiar el contenido de las listas, \nserá necesario presionar el botón \"Recargar\" para que los cambios sean aplicados."
         }


### PR DESCRIPTION
## What's Changed
* Updated the verb "mirar" to "ver" to align with the common Spanish (Spain), reflecting the act of watching content on television rather than looking at the device itself.
* Replaced "en vivo" with "en directo" to match the terminology [used on Twitch.tv](https://i.imgur.com/RJ81JQA.png) and commonly in Spain: 
* Updated the `how_it_works_text` to eliminate repetitions and restructured the sentences for a more natural, human-like expression.

Related with #2