### PR TITLE
Check remaining minutes before mining drop

### DIFF
--- a/inventory.py
+++ b/inventory.py
@@ -100,7 +100,7 @@ class BaseDrop:
             self.preconditions_met  # preconditions are met
             and not self.is_claimed  # isn't already claimed
             # is within the timeframe
-            and self.starts_at <= datetime.now(timezone.utc) < self.ends_at
+            and self.starts_at <= datetime.now(timezone.utc) < self.ends_at - timedelta(minutes=self.remaining_minutes)
         )
 
     def can_earn(self, channel: Channel | None = None) -> bool:
@@ -110,7 +110,7 @@ class BaseDrop:
         return (
             self.preconditions_met  # preconditions are met
             and not self.is_claimed  # isn't already claimed
-            and self.ends_at > datetime.now(timezone.utc)
+            and self.ends_at - timedelta(minutes=self.remaining_minutes) > datetime.now(timezone.utc)
             and self.starts_at < stamp
         )
 
@@ -350,7 +350,7 @@ class DropsCampaign:
         # and uses a future timestamp to see if we can earn this campaign later
         return (
             self.linked
-            and self.ends_at > datetime.now(timezone.utc)
+            and self.ends_at - timedelta(minutes=self.remaining_minutes) > datetime.now(timezone.utc)
             and self.starts_at < stamp
             and any(drop.can_earn_within(stamp) for drop in self.drops)
         )


### PR DESCRIPTION
### This just serves as an example showing where this should be implemented. This current implementation would make the miner refuse to mine a campaign if any drop inside it is impossible to get in time, even if previous drops could be mined. More in #64 