### PR TITLE
update hash and add new variable includeIsDJ

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -331,7 +331,7 @@ GQL_OPERATIONS: dict[str, GQLOperation] = {
         variables={
             "limit": ...,  # limit of channels returned
             "slug": ...,  # game slug
-            "includeIsDJ": True,
+            "includeIsDJ": False,
             "imageWidth": 50,
             "options": {
                 "broadcasterLanguages": [],

--- a/constants.py
+++ b/constants.py
@@ -327,10 +327,11 @@ GQL_OPERATIONS: dict[str, GQLOperation] = {
     # returns live channels for a particular game
     "GameDirectory": GQLOperation(
         "DirectoryPage_Game",
-        "3c9a94ee095c735e43ed3ad6ce6d4cbd03c4c6f754b31de54993e0d48fd54e30",
+        "c7c9d5aad09155c4161d2382092dc44610367f3536aac39019ec2582ae5065f9",
         variables={
             "limit": ...,  # limit of channels returned
             "slug": ...,  # game slug
+            "includeIsDJ": True,
             "imageWidth": 50,
             "options": {
                 "broadcasterLanguages": [],


### PR DESCRIPTION
Issue from: https://github.com/DevilXD/TwitchDropsMiner/issues/526#issuecomment-2273883933

Closes: https://github.com/Windows200000/TwitchDropsMiner-updated/issues/159

---

UPD: Old hash renewed and working again...

---

Hash has been updated:
```diff
-3c9a94ee095c735e43ed3ad6ce6d4cbd03c4c6f754b31de54993e0d48fd54e30
+c7c9d5aad09155c4161d2382092dc44610367f3536aac39019ec2582ae5065f9
```

---

Also added new variable `includeIsDJ`, without it server return response:
```
{'errors': [{'message': 'Variable "includeIsDJ" has invalid value null.\nExpected type "Boolean!", found null.', 'locations': [{'line': 1, 'column': 154}]}], 'extensions': {'durationMilliseconds': 2, 'operationName': 'DirectoryPage_Game', 'requestID': '01J4Q51NTKF0Y71G3CC'}}
```

That variable adds `isParticipatingDJ`:
```diff
    {
        "cursor": "eyJzIjoxMzY1LjM4MjQ1NjU1OTU0NDIsImQiOmZhbHNlLCJ0Ijp0cnVlfQ==",
        "node": {
            "id": "42708821592",
            "title": "Der Weg zum Set Bonus",
            "viewersCount": 1365,
            "previewImageURL": "https://static-cdn.jtvnw.net/previews-ttv/live_user_keysjore-440x248.jpg",
            "broadcaster": {
                "id": "28552242",
                "login": "keysjore",
                "displayName": "KeysJore",
                "roles": {
                    "isPartner": true,
+                   "isParticipatingDJ": false,
                    "__typename": "UserRoles"
                },
                "profileImageURL": "https://static-cdn.jtvnw.net/jtv_user_pictures/keysjore-profile_image-5cf0ec46d8075838-50x50.jpeg",
                "primaryColorHex": null,
                "__typename": "User"
            },
            "freeformTags": [
                {
                    ...
                },
                {
                    ...
                }
            ],
            "type": "live",
            "game": {
                ...
            },
            "previewThumbnailProperties": {
               ...
            },
            "__typename": "Stream"
        },
        "trackingID": null,
        "__typename": "StreamEdge"
    },
```
That used for:
![image](https://github.com/user-attachments/assets/de4aab74-2fdc-41b5-aa26-17a0a48e614b)